### PR TITLE
[imp #20] Implement change stream as Observable

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -105,7 +105,8 @@ object SohvaBuild extends Build {
     "org.gnieh" %% "diffson" % "0.2",
     "com.jsuereth" %% "scala-arm" % "1.3",
     "net.liftweb" %% "lift-json" % "2.5",
-    "org.slf4j" % "slf4j-api" % "1.7.2"
+    "org.slf4j" % "slf4j-api" % "1.7.2",
+    "com.netflix.rxjava" % "rxjava-scala" % "0.17.4"
   )
 
   lazy val testing = Project(id = "sohva-testing",

--- a/sohva-client/src/main/scala/gnieh/sohva/CouchClient.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/CouchClient.scala
@@ -37,6 +37,6 @@ trait CouchClient[Result[_]] extends CouchDB[Result] {
   def startOAuthSession(consumerKey: String, consumerSecret: String, token: String, secret: String): OAuthSession[Result]
 
   /** Shuts down this instance of couchdb client. */
-  def shutdown
+  def shutdown()
 
 }

--- a/sohva-client/src/main/scala/gnieh/sohva/Database.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/Database.scala
@@ -55,8 +55,10 @@ trait Database[Result[_]] {
   /** Indicates whether this database exists */
   def exists: Result[Boolean]
 
-  /** Registers to the change stream of this database with potential filter */
-  def changes(filter: Option[String] = None): ChangeStream
+  /** Registers to the change stream of this database with potential filter and
+   *  since some revision. If no revision is given changes that occurred before the
+   *  connection was established are not sent */
+  def changes(since: Option[Int] = None, filter: Option[String] = None): ChangeStream
 
   /** Creates this database in the couchdb instance if it does not already exist.
    *  Returns <code>true</code> iff the database was actually created.

--- a/sohva-client/src/main/scala/gnieh/sohva/async/CouchClient.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/async/CouchClient.scala
@@ -77,7 +77,7 @@ class CouchClient(val host: String = "localhost",
   def startOAuthSession(consumerKey: String, consumerSecret: String, token: String, secret: String) =
     new OAuthSession(consumerKey, consumerSecret, token, secret, this)
 
-  def shutdown =
+  def shutdown() =
     IO(Http) ! Http.CloseAll
 
   // ========== internals ==========

--- a/sohva-client/src/main/scala/gnieh/sohva/control/Database.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/control/Database.scala
@@ -56,8 +56,9 @@ class Database private[sohva] (wrapped: ADatabase) extends gnieh.sohva.Database[
   def exists: Try[Boolean] =
     synced(wrapped.exists)
 
-  def changes(filter: Option[String] = None): ChangeStream =
-    wrapped.changes(filter)
+  @inline
+  def changes(since: Option[Int] = None, filter: Option[String] = None): ChangeStream =
+    wrapped.changes(since, filter)
 
   @inline
   def create: Try[Boolean] =

--- a/sohva-client/src/main/scala/gnieh/sohva/package.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/package.scala
@@ -21,6 +21,10 @@ import java.security.MessageDigest
 
 import scala.util.Random
 
+import rx.lang.scala._
+
+import net.liftweb.json._
+
 /** Contains all the classes needed to interact with a couchdb server.
  *  Classes in this package allows the user to:
  *  - create/delete new databases into a couchdb instance,

--- a/sohva-client/src/main/scala/gnieh/sohva/sync/Database.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/sync/Database.scala
@@ -57,8 +57,9 @@ class Database private[sohva] (wrapped: ADatabase) extends gnieh.sohva.Database[
   def exists: Boolean =
     synced(wrapped.exists)
 
-  def changes(filter: Option[String] = None): ChangeStream =
-    wrapped.changes(filter)
+  @inline
+  def changes(since: Option[Int] = None, filter: Option[String] = None): ChangeStream =
+    wrapped.changes(since, filter)
 
   @inline
   def create: Boolean =

--- a/sohva-client/src/test/scala/gnieh/sohva/test/SohvaTestSuite.scala
+++ b/sohva-client/src/test/scala/gnieh/sohva/test/SohvaTestSuite.scala
@@ -47,6 +47,7 @@ abstract class SohvaTestSpec extends FlatSpec with ShouldMatchers with BeforeAnd
     db.delete
     // logout
     session.logout
+    couch.shutdown()
     system.shutdown()
   }
 


### PR DESCRIPTION
Using rxjava-scala, we are able to provide a high-level, nice-to-use API
for being notified about changes in the database. By combining the power
of akka actors and `Observables` such streams can be combined and worked
with in any fashion the user wants it.

closes #20
