### PR TITLE
Add custom serializers to all clients

### DIFF
--- a/sohva-client/src/main/scala/gnieh/sohva/Database.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/Database.scala
@@ -120,12 +120,14 @@ trait Database[Result[_]] {
 
   /** Creates a document in the database and returns its identifier and revision.
    *  If the json version of the object has a `_id` field, this identifier is used for the document,
-   *  otherwise a new one is generated. */
+   *  otherwise a new one is generated.
+   */
   def createDoc(doc: Any): Result[DbResult]
 
   /** Creates a set of documents in the database and returns theirs identifiers and revision.
    *  If the json version of an object has a `_id` field, this identifier is used for the document,
-   *  otherwise a new one is generated. */
+   *  otherwise a new one is generated.
+   */
   def createDocs(doc: List[Any]): Result[List[DbResult]]
 
   /** Copies the origin document to the target document.

--- a/sohva-client/src/main/scala/gnieh/sohva/Design.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/Design.scala
@@ -117,7 +117,8 @@ trait Design[Result[_]] {
   def deleteFilter(name: String): Result[Unit]
 
   /** Creates or updates the list of rewrite rules.
-   *  If the design does not exist yet, it is created. */
+   *  If the design does not exist yet, it is created.
+   */
   def saveRewriteRules(rules: List[RewriteRule]): Result[Unit]
 
   /** Retrieves the rewrite rules associated to this design document. */

--- a/sohva-client/src/main/scala/gnieh/sohva/async/Design.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/async/Design.scala
@@ -267,11 +267,11 @@ class Design(val db: Database,
     }
 
   def getRewriteRules(): Future[List[RewriteRule]] =
-    for(design <- getDesignDocument)
+    for (design <- getDesignDocument)
       yield design match {
-        case Some(d) => d.rewrites
-        case None    => Nil
-      }
+      case Some(d) => d.rewrites
+      case None    => Nil
+    }
 
   // helper methods
 

--- a/sohva-client/src/main/scala/gnieh/sohva/control/CouchClient.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/control/CouchClient.scala
@@ -39,10 +39,11 @@ class CouchClient private[control] (override val wrapped: ACouchClient) extends 
   def this(host: String = "localhost",
     port: Int = 5984,
     ssl: Boolean = false,
-    version: String = "1.4")(
+    version: String = "1.4",
+    custom: List[SohvaSerializer[_]] = Nil)(
       implicit system: ActorSystem,
       timeout: Timeout) =
-    this(new ACouchClient(host, port, ssl, version))
+    this(new ACouchClient(host, port, ssl, version, custom))
 
   def startCookieSession =
     new CookieSession(wrapped.startCookieSession)

--- a/sohva-client/src/main/scala/gnieh/sohva/control/Update.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/control/Update.scala
@@ -30,7 +30,7 @@ class Update(val wrapped: AUpdate) extends gnieh.sohva.Update[Try] {
     synced(wrapped.exists)
 
   def query[Body, Resp: Unmarshaller](body: Body, docId: Option[String] = None, parameters: Map[String, String] = Map()): Try[Resp] =
-    synced(wrapped.query[Body,Resp](body, docId, parameters))
+    synced(wrapped.query[Body, Resp](body, docId, parameters))
 
   def queryForm[Resp: Unmarshaller](data: Map[String, String], docId: String, parameters: Map[String, String] = Map()): Try[Resp] =
     synced(wrapped.queryForm[Resp](data, docId, parameters))

--- a/sohva-client/src/main/scala/gnieh/sohva/sync/CouchClient.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/sync/CouchClient.scala
@@ -37,10 +37,11 @@ class CouchClient private[sync] (override val wrapped: ACouchClient) extends Cou
   def this(host: String = "localhost",
     port: Int = 5984,
     ssl: Boolean = false,
-    version: String = "1.4")(
+    version: String = "1.4",
+    custom: List[SohvaSerializer[_]] = Nil)(
       implicit sysmte: ActorSystem,
       timeout: Timeout) =
-    this(new ACouchClient(host, port, ssl, version))
+    this(new ACouchClient(host, port, ssl, version, custom))
 
   def startCookieSession =
     new CookieSession(wrapped.startCookieSession)

--- a/sohva-client/src/main/scala/gnieh/sohva/sync/Update.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/sync/Update.scala
@@ -28,7 +28,7 @@ class Update(val wrapped: AUpdate) extends gnieh.sohva.Update[Identity] {
     synced(wrapped.exists)
 
   def query[Body, Resp: Unmarshaller](body: Body, docId: Option[String] = None, parameters: Map[String, String] = Map()): Resp =
-    synced(wrapped.query[Body,Resp](body, docId, parameters))
+    synced(wrapped.query[Body, Resp](body, docId, parameters))
 
   def queryForm[Resp: Unmarshaller](data: Map[String, String], docId: String, parameters: Map[String, String] = Map()): Resp =
     synced(wrapped.queryForm[Resp](data, docId, parameters))


### PR DESCRIPTION
Until now, only the asynchronous client could benefit from this feature
which was quite annoying.