### PR TITLE
Use since value for change feed

### DIFF
--- a/sohva-client/src/main/scala/gnieh/sohva/async/ChangeStream.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/async/ChangeStream.scala
@@ -46,7 +46,7 @@ class ChangeStream(database: Database, since: Option[Int], filter: Option[String
 
   private val subscriptionId = new AtomicLong
 
-  private val actor = system.actorOf(Props(new ChangeActor(database, filter)))
+  private val actor = system.actorOf(Props(new ChangeActor(database, since, filter)))
 
   val stream: Observable[(String, Option[JObject])] =
     Observable { observer =>
@@ -77,7 +77,7 @@ class ChangeStream(database: Database, since: Option[Int], filter: Option[String
  *
  *  @author Lucas Satabin
  */
-private class ChangeActor(database: Database, filter: Option[String]) extends Actor with ActorLogging {
+private class ChangeActor(database: Database, since: Option[Int], filter: Option[String]) extends Actor with ActorLogging {
 
   implicit def system = context.system
 
@@ -103,7 +103,7 @@ private class ChangeActor(database: Database, filter: Option[String]) extends Ac
       val params = {
         val base = Map(
           "feed" -> "continuous",
-          "since" -> "now",
+          "since" -> since.map(_.toString).getOrElse("now"),
           "include_docs" -> "true",
           "heartbeat" -> "true"
         )
@@ -196,4 +196,3 @@ private class ChangeActor(database: Database, filter: Option[String]) extends Ac
 private case class Unsubscribe(id: Long)
 private case class Subscribe(id: Long, observer: Observer[(String, Option[JObject])])
 private case object CloseStream
-

--- a/sohva-client/src/test/scala/gnieh/sohva/test/TestChanges.scala
+++ b/sohva-client/src/test/scala/gnieh/sohva/test/TestChanges.scala
@@ -201,6 +201,33 @@ class TestChanges extends SohvaTestSpec with ShouldMatchers with AsyncAssertions
 
   }
 
+  it should "be notified of past changes if since was specified" in {
+
+    val w = new Waiter
+
+    val d1 = db.saveDoc(TestDoc("doc1", 8)())
+
+    val seqFollowingD1 = db.info.map(_.update_seq)
+
+    val d2 = db.saveDoc(TestDoc("doc2", 17)())
+
+    val changes = db.changes(seqFollowingD1, None)
+
+    try {
+      val sub = changes.subscribe { case (_, doc) =>
+        doc should be('defined)
+        doc.value.extract[TestDoc].toto should be > (10)
+        w.dismiss()
+      }
+
+      val d3 = db.saveDoc(d1.copy(toto = 14)(_rev = d1._rev))
+
+      w.await(timeout(5.seconds), dismissals(2))
+
+    } finally changes.close()
+
+  }
+
   "all registered handlers" should "be notified" in withChanges { changes =>
 
     val w = new Waiter
@@ -262,4 +289,3 @@ class TestChanges extends SohvaTestSpec with ShouldMatchers with AsyncAssertions
   }
 
 }
-


### PR DESCRIPTION
Currently the `since` value is ignored for `ChangeStream`. Using `since` is a good way to track changes following a query for current state.

This PR adds `since` handling and tests to ensure it works as expected. 