### PR TITLE
Make API more comprehensive and clean

### DIFF
--- a/sohva-client/src/main/scala/gnieh/sohva/CouchDB.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/CouchDB.scala
@@ -86,6 +86,20 @@ abstract class CouchDB extends SprayJsonSupport {
         f"Unable to fetch databases list from $uri"
     ) yield asStringList(dbs)
 
+  /** Returns the list of nodes known by this node and the clusters.
+   *
+   *  @group CouchDB2
+   */
+  def membership: Future[Membership] =
+    for {
+      mem <- http(HttpRequest(uri = uri / "_membership")).withFailureMessage(f"Unable to fetch membership frin $uri")
+    } yield mem.convertTo[Membership]
+
+  /** Restarts the CouchDB instance. */
+  def restart: Future[Boolean] =
+    for (resp <- http(HttpRequest(HttpMethods.POST, uri = uri / "_restart")).withFailureMessage(f"Unable to restart instance at $uri"))
+      yield resp.asJsObject("ok").convertTo[Boolean]
+
   /** Returns one UUID */
   def _uuid: Future[String] =
     for (uuid <- _uuids(1))
@@ -220,3 +234,4 @@ final case class CouchInfo(couchdb: String, version: String)
 
 private[sohva] final case class Uuids(uuids: List[String])
 
+final case class Membership(all_nodes: Vector[String], cluster_nodes: Vector[String])

--- a/sohva-client/src/main/scala/gnieh/sohva/Design.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/Design.scala
@@ -322,6 +322,11 @@ class Design(val db: Database,
       case None    => Nil
     }
 
+  /** Requests compaction of this design. */
+  def compact: Future[Boolean] =
+    for (resp <- db.couch.http(HttpRequest(HttpMethods.POST, uri = db.uri / "_compact" / name)).withFailureMessage(f""))
+      yield resp.asJsObject("ok").convertTo[Boolean]
+
   // helper methods
 
   private def designDoc(json: JsValue) =

--- a/sohva-client/src/main/scala/gnieh/sohva/DocumentOps.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/DocumentOps.scala
@@ -1,0 +1,139 @@
+/*
+* This file is part of the sohva project.
+* Copyright (c) 2016 Lucas Satabin
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package gnieh.sohva
+
+import strategy.Strategy
+
+import akka.http.scaladsl.model._
+import akka.http.scaladsl.marshalling._
+import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport
+
+import spray.json._
+
+import scala.concurrent._
+
+import org.slf4j.LoggerFactory
+
+abstract class DocumentOps extends SohvaProtocol with SprayJsonSupport {
+
+  implicit val ec: ExecutionContext
+
+  val credit: Int
+
+  val strategy: Strategy
+
+  /** Returns the document identified by the given id if it exists */
+  def getDocById[T: JsonReader](id: String, revision: Option[String] = None): Future[Option[T]] =
+    for (raw <- optHttp(HttpRequest(uri = uri / id <<? revision.flatMap(r => if (r.nonEmpty) Some("rev" -> r) else None))).withFailureMessage(f"Failed to fetch document by ID $id and revision $revision"))
+      yield raw.map(_.convertTo[T])
+
+  /** Creates or updates the given object as a document into this database
+   *  The given object must have an `_id` and an optional `_rev` fields
+   *  to conform to the couchdb document structure.
+   *  The saved revision is returned. If something went wrong, an exception is raised
+   */
+  def saveDoc[T: CouchFormat](doc: T): Future[T] = {
+    val format = implicitly[CouchFormat[T]]
+    (for {
+      upd <- resolver(credit, format._id(doc), format._rev(doc), doc.toJson)
+      res <- update[T](upd.convertTo[DocUpdate])
+    } yield res) withFailureMessage f"Unable to save document with ID ${format._id(doc)} at revision ${format._rev(doc)}"
+  }
+
+  protected[this] def saveRawDoc(doc: JsValue): Future[JsValue] = doc match {
+    case JsObject(fields) =>
+      val idRev = for {
+        id <- fields.get("_id").map(_.convertTo[String])
+        rev = fields.get("_rev").map(_.convertTo[String])
+      } yield (id, rev)
+      idRev match {
+        case Some((id, rev)) =>
+          (for {
+            upd <- resolver(credit, id, rev, doc)
+            res <- updateRaw(upd.convertTo[DocUpdate])
+          } yield res) withFailureMessage f"Failed to update raw document with ID $id and revision $rev"
+        case None =>
+          Future.failed(new SohvaException(f"Not a couchdb document: ${doc.prettyPrint}"))
+      }
+    case _ =>
+      Future.failed(new SohvaException(f"Not a couchdb document: ${doc.prettyPrint}"))
+  }
+
+  /* the resolver is responsible for applying the merging strategy on conflict and retrying
+   * to save the document after resolution process */
+  private def resolver(credit: Int, docId: String, baseRev: Option[String], current: JsValue): Future[JsValue] = current match {
+    case JsNull =>
+      LoggerFactory.getLogger(getClass).info("No document to save")
+      Future.successful(DocUpdate(true, docId, baseRev.getOrElse("")).toJson)
+    case _ =>
+      (for {
+        entity <- Marshal(current).to[RequestEntity]
+        res <- http(HttpRequest(HttpMethods.PUT, uri = uri / docId, entity = entity))
+      } yield res).recoverWith {
+        case exn @ ConflictException(_) if credit > 0 =>
+          LoggerFactory.getLogger(getClass).info("Conflict occurred, try to resolve it")
+          // try to resolve the conflict and save again
+          for {
+            // get the base document if any
+            base <- getDocById[JsValue](docId, baseRev)
+            // get the last document
+            last <- getDocById[JsValue](docId)
+            // apply the merge strategy between base, last and current revision of the document
+            lastRev = last collect {
+              case JsObject(fs) if fs.contains("_rev") => fs("_rev").convertTo[String]
+            }
+            resolved = strategy(base, last, current)
+            res <- resolved match {
+              case Some(resolved) => resolver(credit - 1, docId, lastRev, resolved)
+              case None           => Future.failed(exn)
+            }
+          } yield res
+      } withFailureMessage f"Unable to resolve document with ID $docId at revision $baseRev"
+  }
+
+  private[this] def update[T: JsonReader](res: DocUpdate) = res match {
+    case DocUpdate(true, id, rev) =>
+      getDocById[T](id, Some(rev)).map(_.get)
+    case DocUpdate(false, id, _) =>
+      Future.failed(new SohvaException(f"Document $id could not be saved"))
+  }
+
+  private[this] def updateRaw(res: DocUpdate) = res match {
+    case DocUpdate(true, id, rev) =>
+      getDocById[JsValue](id, Some(rev)).map(_.get)
+    case DocUpdate(false, id, _) =>
+      Future.failed(new SohvaException("Document $id could not be saved"))
+  }
+
+  /** Deletes the document from the database.
+   *  The document will only be deleted if the caller provided the last revision
+   */
+  def deleteDoc[T: CouchFormat](doc: T): Future[Boolean] = {
+    val format = implicitly[CouchFormat[T]]
+    for (
+      res <- http(HttpRequest(HttpMethods.DELETE, uri = uri / format._id(doc) <<? Map("rev" -> format._rev(doc).getOrElse("")))) withFailureMessage
+        f"Failed to delete document with ID ${format._id(doc)} at revision ${format._rev(doc)} from $uri"
+    ) yield res.convertTo[OkResult].ok
+  }
+
+  protected[sohva] def http(req: HttpRequest): Future[JsValue]
+
+  protected[sohva] def optHttp(req: HttpRequest): Future[Option[JsValue]]
+
+  protected[sohva] val uri: Uri
+
+}

--- a/sohva-client/src/main/scala/gnieh/sohva/Local.scala
+++ b/sohva-client/src/main/scala/gnieh/sohva/Local.scala
@@ -1,0 +1,44 @@
+/*
+* This file is part of the sohva project.
+* Copyright (c) 2016 Lucas Satabin
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package gnieh.sohva
+
+import akka.http.scaladsl.model.HttpRequest
+
+import spray.json.JsValue
+
+import scala.concurrent.Future
+
+class Local(db: Database) extends DocumentOps {
+
+  implicit val ec =
+    db.ec
+
+  val credit =
+    db.credit
+
+  val strategy =
+    db.strategy
+
+  protected[sohva] def http(req: HttpRequest): Future[JsValue] =
+    db.http(req)
+
+  protected[sohva] def optHttp(req: HttpRequest): Future[Option[JsValue]] =
+    db.optHttp(req)
+
+  protected[sohva] val uri = db.uri / "_local"
+
+}

--- a/sohva-client/src/test/scala/gnieh/sohva/test/TestBasic.scala
+++ b/sohva-client/src/test/scala/gnieh/sohva/test/TestBasic.scala
@@ -109,7 +109,7 @@ class TestBasic extends SohvaTestSpec with Matchers {
       case OkResult(true, id, rev) =>
 
         val newId = id.value
-        val saved = synced(db.getRawDocById(newId))
+        val saved = synced(db.getDocById[JsValue](newId))
         saved.value match {
           case JsObject(fields) =>
             fields.get("value").value should be(JsNumber(3))


### PR DESCRIPTION
Some operations were there in previous versions but not implemented in
Sohva. These missing features were mainly:

 - local documents handling
 - missing revisions handling

Some other operations are new in CouchDB 2.0. These are marked in the
documentation as being part of the group CouchDB2.

Depreciate temporary views as well.