### PR TITLE
[fix #60] Correctly parse error rows

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,8 @@ lazy val globalSettings = Seq(
   libraryDependencies ++= globalDependencies,
   parallelExecution := false,
   fork in Test := true,
-  scalacOptions ++= Seq("-deprecation", "-feature")
+  scalacOptions ++= Seq("-deprecation", "-feature"),
+  scalacOptions in (Compile, doc) ++= Seq("-groups")
 )
 
 lazy val scalariform = scalariformSettings ++ Seq(

--- a/src/main/scala/gnieh/sohva/Database.scala
+++ b/src/main/scala/gnieh/sohva/Database.scala
@@ -69,6 +69,11 @@ import akka.util.ByteString
  *  @param credit The credit assigned to the conflict resolver. It represents the number of times the client tries to save the document before giving up.
  *  @param strategy The strategy being used to resolve conflicts
  *
+ *  @groupdesc LowLevel Low-level classes that may break compatibility even between patch and minor versions
+ *  @groupdesc CouchDB1 Operation only available in CouchDB 1
+ *  @groupdesc CouchDB2 Operation only available in CouchDB 2
+ *  @groupprio LowLevel 1001
+ *
  *  @author Lucas Satabin
  */
 class Database private[sohva] (
@@ -176,7 +181,10 @@ class Database private[sohva] (
       ) withFailureMessage f"Failed to access _all_docs view for $uri"
     } yield for (Row(Some(id), _, _, _) <- res.rows) yield id
 
-  /** Returns the raw representation of the document identified by the given id if it exists. */
+  /**
+   * Returns the raw representation of the document identified by the given id if it exists.
+   *  @group LowLevel
+   */
   @deprecated("Use `getDocById` with return type `JsValue` instead", "2.0.0")
   def getRawDocById(id: String, revision: Option[String] = None): Future[Option[JsValue]] =
     getDocById[JsValue](id, revision)

--- a/src/main/scala/gnieh/sohva/package.scala
+++ b/src/main/scala/gnieh/sohva/package.scala
@@ -35,6 +35,9 @@ import scala.concurrent.{
  *  - create/update/delete couchdb users,
  *  - use couchdb authentication API to create sessions and use built-in permission system.
  *
+ *  @groupdesc LowLevel Low-level classes that may break compatibility even between patch and minor versions
+ *  @groupprio LowLevel 1001
+ *
  *  @author Lucas Satabin
  *
  */

--- a/src/test/scala/gnieh/sohva/test/TestViews.scala
+++ b/src/test/scala/gnieh/sohva/test/TestViews.scala
@@ -67,6 +67,27 @@ class TestViews extends SohvaTestSpec with Matchers with BeforeAndAfterEach {
 
   }
 
+  "querying a view with some unknown keys" should "return error results in raw view query" in {
+
+    val view = db.builtInView("_all_docs")
+
+    val rawViewResult = synced(view.queryRaw(keys = List("unknown_doc".toJson)))
+
+    rawViewResult.rows.size should be(1)
+    rawViewResult.rows(0) should be(ErrorRawRow("unknown_doc".toJson, "not_found"))
+
+  }
+
+  it should "not return error results in type view query" in {
+
+    val view = db.builtInView("_all_docs")
+
+    val viewResult = synced(view.query(keys = List("unknown_doc")))
+
+    viewResult.rows.size should be(0)
+
+  }
+
   "querying a view with no parameter" should "result in all emitted key/values to be returned" in {
 
     val view = db.design("test_design").view("test_view")
@@ -99,7 +120,7 @@ class TestViews extends SohvaTestSpec with Matchers with BeforeAndAfterEach {
 
   "querying a built-in view" should "be similar to querying user defined view" in {
 
-    val all = synced(db._all_docs(startkey = Some("view_doc"), endkey = Some("view_docZ")))
+    val all = synced(db.allDocs(startkey = Some("view_doc"), endkey = Some("view_docZ")))
 
     all.size should be(docs.size)
     all should be(docs.map(doc => doc._id).sorted)


### PR DESCRIPTION
The low-level parsing of view results now interprets correctly the error
rows in view results. The high-level one, filters these rows out, so
that no break occurs in the high-level API.