### PR TITLE
Add closed since type

### DIFF
--- a/src/main/scala/gnieh/sohva/Since.scala
+++ b/src/main/scala/gnieh/sohva/Since.scala
@@ -1,0 +1,36 @@
+/*
+* This file is part of the sohva project.
+* Copyright (c) 2017 Lucas Satabin
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package gnieh.sohva
+
+import spray.json._
+
+/** start sequence of a change stream. */
+sealed trait Since {
+  def option: Option[String]
+}
+/** Start at the given update sequence. */
+final case class UpdateSequence(seq: JsValue) extends Since {
+  def option = Some(CompactPrinter(seq))
+}
+/** Start with changes from now on. */
+case object Now extends Since {
+  def option = Some("now")
+}
+/** Start at the beginning of time. */
+case object Origin extends Since {
+  def option = None
+}

--- a/src/main/scala/gnieh/sohva/package.scala
+++ b/src/main/scala/gnieh/sohva/package.scala
@@ -46,7 +46,7 @@ package object sohva {
   // register the COPY method
   val COPY = HttpMethod.custom("COPY")
 
-  val now = Some(Left("now"))
+  val now = Now
 
   private[sohva] implicit class EnhencedCloseable[T <: Closeable](val closeable: T) extends AnyVal {
 

--- a/src/test/scala/gnieh/sohva/test/TestChanges.scala
+++ b/src/test/scala/gnieh/sohva/test/TestChanges.scala
@@ -32,7 +32,7 @@ class TestChanges extends AsyncSohvaTestSpec with Matchers {
 
   "registering to a database since now" should "not return previous events" in {
 
-    val stream = db.changes.stream(since = now)
+    val stream = db.changes.all(since = now)
 
     val (kill, res) = stream.toMat(Sink.fold(0) { case (c, _) => c + 1 })(Keep.both).run()
 
@@ -45,7 +45,7 @@ class TestChanges extends AsyncSohvaTestSpec with Matchers {
 
   it should "be notified about new events" taggedAs (NoTravis) in {
 
-    val stream = db.changes.stream(since = now, style = Some("all_docs"))
+    val stream = db.changes.all(since = now, style = Some("all_docs"))
 
     val res = stream.takeWithin(5.seconds).toMat(Sink.fold(0) { case (c, _) => c + 1 })(Keep.right).run()
 
@@ -60,7 +60,7 @@ class TestChanges extends AsyncSohvaTestSpec with Matchers {
 
   it should "not be notified anymore when closed" taggedAs (NoTravis) in {
 
-    val stream = db.changes.stream(since = now, style = Some("all_docs"))
+    val stream = db.changes.all(since = now, style = Some("all_docs"))
 
     val (kill, res) = stream.toMat(Sink.fold(0) { case (c, _) => c + 1 })(Keep.both).run()
 
@@ -77,7 +77,7 @@ class TestChanges extends AsyncSohvaTestSpec with Matchers {
 
   "several registered stream" should "all be notified" taggedAs (NoTravis) in {
 
-    val stream = db.changes.stream(since = now, style = Some("all_docs")).takeWithin(1.seconds).toMat(Sink.fold(0) { case (c, _) => c + 1 })(Keep.right)
+    val stream = db.changes.all(since = now, style = Some("all_docs")).takeWithin(1.seconds).toMat(Sink.fold(0) { case (c, _) => c + 1 })(Keep.right)
 
     val res1 = stream.run()
     val res2 = stream.run()


### PR DESCRIPTION
It is much more robust to use a closed type given that accepted values are well known and defined.
Moreover a named type is much more explicit than an optional `Either`.

fix #90