### PR TITLE
Add mixed bulk operations

### DIFF
--- a/src/main/scala/gnieh/sohva/BulkOp.scala
+++ b/src/main/scala/gnieh/sohva/BulkOp.scala
@@ -1,0 +1,21 @@
+/*
+* This file is part of the sohva project.
+* Copyright (c) 2017 Lucas Satabin
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package gnieh.sohva
+
+sealed trait BulkOp[+T]
+case class Delete(id: String, rev: String) extends BulkOp[Nothing]
+case class Save[T](doc: T) extends BulkOp[T]

--- a/src/main/scala/gnieh/sohva/SohvaProtocol.scala
+++ b/src/main/scala/gnieh/sohva/SohvaProtocol.scala
@@ -147,6 +147,15 @@ trait SohvaProtocol extends DefaultJsonProtocol with MangoProtocol with CouchFor
 
   private[sohva] implicit val uuidsFormat = jsonFormat1(Uuids)
 
+  implicit def BulkOpWriter[T: CouchFormat]: JsonWriter[BulkOp[T]] = new JsonWriter[BulkOp[T]] {
+
+    def write(op: BulkOp[T]): JsValue = op match {
+      case Delete(id, rev) => JsObject(Map("_id" -> JsString(id), "_rev" -> JsString(rev), "_deleted" -> JsBoolean(true)))
+      case Save(doc)       => doc.toJson
+    }
+
+  }
+
   implicit object DbResultFormat extends RootJsonFormat[DbResult] {
 
     def read(value: JsValue): DbResult =


### PR DESCRIPTION
It is useful to perform both updates and deletes with one single query,
thus saving a roundtrip to the server.

fix #89