### PR TITLE
[fix #97] Change purge_seq type from Long to JsValue

### DIFF
--- a/src/main/scala/gnieh/sohva/Database.scala
+++ b/src/main/scala/gnieh/sohva/Database.scala
@@ -620,7 +620,7 @@ final case class InfoResult(
     doc_del_count: Long,
     data_size: Long,
     instance_start_time: String,
-    purge_seq: Long,
+    purge_seq: JsValue,
     update_seq: JsValue,
     sizes: Option[Sizes],
     other: Option[Map[String, JsValue]])


### PR DESCRIPTION
In CouchDB 2.3, the purge_seq in the basic database info changed
from a Long to a String.
This change allows Sohva to support both CouchDB 2.2 (Long purge_seq)
and 2.3 (String purge_seq).